### PR TITLE
Task/383 use tls in mongodb

### DIFF
--- a/profileservice/Dockerfile
+++ b/profileservice/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="ywkim@illinois.edu"
 
 EXPOSE 5000
 
-RUN wget wget https://assets.rokwire.illinois.edu/mongo-ca.pem /etc/ssl/certs/.
+RUN apk update && apk add wget && \
+  wget https://assets.rokwire.illinois.edu/mongo-ca.pem -O /etc/ssl/certs/mongo-ca.pem
 
 WORKDIR /usr/src/app/lib
 


### PR DESCRIPTION
@sandeep-ps I am directly downloading mongo-ca.pem in /etc/ssl/certs folder and it works fine.
@bingzhang @wenjzhu If you're using MongoDB, mimic this PR to your building block.