### PR TITLE
Fix datetime format in event response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add nullable to several non-pii fields. [#398](https://github.com/rokwire/rokwire-building-blocks-api/issues/398)
 ### Fixed
 - Issue with incompatible Python and Connexion version in Authentication Building Block. [#389](https://github.com/rokwire/rokwire-building-blocks-api/issues/389)
+- Issue with date time format in event response. [#402](https://github.com/rokwire/rokwire-building-blocks-api/issues/402)
 
 ## [1.0.6] - 2020-02-25
 ### Added

--- a/eventservice/api/controllers/events.py
+++ b/eventservice/api/controllers/events.py
@@ -95,7 +95,7 @@ def _get_events_result(query, limit, skip):
                 events.append(subevent_detail)
         else:
             events.append(event)
-    return flask.json.dumps(events), len(events)
+    return flask.json.dumps(events, default=query_params.format_datetime_response), len(events)
 
 
 def tags_search():

--- a/eventservice/api/utils/query_params.py
+++ b/eventservice/api/utils/query_params.py
@@ -149,3 +149,9 @@ def update_coordinates(req_data, coordinates):
     if req_data.get('location.longitude'):
         coordinates[0] = req_data.get('location.longitude')
         req_data['coordinates'] = coordinates
+
+
+def format_datetime_response(obj):
+    # Example format: Fri, 27 Mar 2020 01:00:00 GMT
+    if isinstance(obj, datetime.datetime):
+        return obj.strftime('%a, %d %b %Y %H:%M:%S GMT')


### PR DESCRIPTION
Closes: #402
We can move the util method to a different place later. 