### PR TITLE
Stop printing logs from the logging building block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2020-06-05
+## Changed
+- Stop printing logs in the Logging Building Block. [#444](https://github.com/rokwire/rokwire-building-blocks-api/issues/444)
+
 ## [1.3.0] - 2020-05-15
 ## Added
 - Add more fields in PII and updated API design. [#411](https://github.com/rokwire/rokwire-building-blocks-api/issues/411)

--- a/loggingservice/api/controllers/logs.py
+++ b/loggingservice/api/controllers/logs.py
@@ -34,9 +34,12 @@ def post():
             # db[LOGGING_COLL_NAME].insert_many(in_json)
 
             # Write incoming click stream data to log (for easy integration with Splunk)
-            for log in in_json:
-                print(json.dumps(log))
-            sys.stdout.flush()
+            # Temporarily disable printing logs to STDOUT.
+
+            # for log in in_json:
+            #     print(json.dumps(log))
+            # sys.stdout.flush()
+            pass
 
     except Exception as ex:
         logging.exception(ex)


### PR DESCRIPTION
@ywkim312, we are temporarily disabling logs. Adding you for information at this time. I will get this PR merged and deployed.