### PR TITLE
Add multistage builds to cut Docker image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Talent Chooser Building Block APIs documentation. [#528](https://github.com/rokwire/rokwire-building-blocks-api/issues/528)
 
 ### Changed
+- Cut appconfigservice container to 98.9MB from 216MB [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
+- Cut auth-middleware-test-svc container to 71.6MB from 935MB [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
+- Cut authservice container to 91.8MB from 228MB [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
+- Cut eventservice container to 141MB from 212MB [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
+- Cut loggingservice container to 94MB from 211MB [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
+- Cut profileservice container to 97.4MB from 215MB [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
+- Reorginized Dockerfile lines to maximize shared layers between containers [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
 - OpenAPI specification file rokwire.yaml file split across different building blocks. [#485](https://github.com/rokwire/rokwire-building-blocks-api/issues/485)
 - Update Swagger-UI version. [#500](https://github.com/rokwire/rokwire-building-blocks-api/issues/500)
 - Rokwire API Doc Dockerfile to integrate multiple OpenAPI specifications file. [#486](https://github.com/rokwire/rokwire-building-blocks-api/issues/486)
@@ -32,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker image vulnerabilities in Events Building Block. [#484](https://github.com/rokwire/rokwire-building-blocks-api/issues/484)
 
 ### Security
+- All containers now run as a non-root user [#524](https://github.com/rokwire/rokwire-building-blocks-api/pull/524)
+  - api-doc runs as nginx user instead of root
+  - the rest run as user nobody
 - Add Yelp's Secret Detector [#530](https://github.com/rokwire/rokwire-building-blocks-api/issues/530)
 - Update secret baseline file [#532](https://github.com/rokwire/rokwire-building-blocks-api/issues/532)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,6 @@ VOLUME /usr/share/nginx/html/app/
 
 ENV BASE_URL="/docs"
 
+USER nginx
+
 CMD ["sh", "/usr/share/nginx/run.sh"]

--- a/appconfigservice/Dockerfile
+++ b/appconfigservice/Dockerfile
@@ -1,24 +1,35 @@
-FROM python:3-alpine3.11
+FROM python:3-alpine3.11 as base
 
-LABEL maintainer="wzhu26@illinois.edu"
+RUN apk --update add openssl ca-certificates
 
 WORKDIR /app
+COPY lib /lib/
 
+FROM base as requirements
+
+# C libs needed to build cryptography a dependency for requests
+RUN apk --update add libffi-dev openssl-dev build-base
+
+COPY appconfigservice/requirements.txt appconfigservice/
+RUN pip install --user --no-warn-script-location --no-cache-dir \
+                -r appconfigservice/requirements.txt
+RUN chmod -R oug+r /root/.local
+RUN find /root/.local -type d -exec chmod oug+x {} +
+
+FROM base
+
+COPY --from=requirements /root/.local /usr/local
 COPY appconfigservice ./appconfigservice
-COPY lib ../lib/
 COPY appconfigservice/appconfig.yaml .
 
 ENV APP_CONFIG_MONGO_URL=""
 ENV APP_CONFIG_URL_PREFIX=""
 
-RUN apk --update add python py-pip openssl ca-certificates py-openssl && \
-  apk --update add --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base && \
-  pip install --upgrade pip && \
-  pip install -r appconfigservice/requirements.txt --no-cache-dir && \
-  apk del build-dependencies
-  
 WORKDIR /app/appconfigservice/api
-
 VOLUME /var/cache/app
+
+LABEL maintainer="wzhu26@illinois.edu"
+
+USER nobody
 
 CMD ["gunicorn", "appconfig_rest_service:app", "--config", "../gunicorn.config.py"]

--- a/auth-middleware-test-svc/Dockerfile
+++ b/auth-middleware-test-svc/Dockerfile
@@ -1,10 +1,30 @@
-FROM python:3
+FROM python:3-alpine3.11 as base
+
+RUN apk --update add openssl ca-certificates
+
+WORKDIR /app
+COPY lib /lib/
+
+FROM base as requirements
+
+# C libs needed to build cryptography a dependency for requests
+RUN apk --update add libffi-dev openssl-dev build-base
+
+COPY auth-middleware-test-svc/requirements.txt /
+RUN pip install --user --no-warn-script-location --no-cache-dir \
+                -r /requirements.txt
+RUN chmod -R oug+r /root/.local
+RUN find /root/.local -type d -exec chmod oug+x {} +
+
+FROM base
+
+#########
 
 LABEL maintainer="ywkim@illinois.edu"
 
-WORKDIR /app
+COPY --from=requirements /root/.local /usr/local
 COPY auth-middleware-test-svc /app/
-COPY lib /lib/
-RUN pip install -r /app/requirements.txt
+
+USER nobody
 
 CMD ["gunicorn", "flaskapp:app", "--config", "/app/gunicorn.config.py"]

--- a/authservice/Dockerfile
+++ b/authservice/Dockerfile
@@ -1,16 +1,36 @@
-FROM python:3-alpine3.11
+FROM python:3-alpine3.11 as base
+
+RUN apk --update add openssl ca-certificates
+
+WORKDIR /app
+COPY lib /lib/
+
+FROM base as requirements
+
+# C libs needed to build cryptography a dependency for requests
+RUN apk --update add libffi-dev openssl-dev build-base
+
+COPY authservice/requirements.txt /app/
+RUN pip install --user --no-warn-script-location --no-cache-dir \
+                -r /app/requirements.txt
+RUN chmod -R oug+r /root/.local
+RUN find /root/.local -type d -exec chmod oug+x {} +
+
+FROM base as prod
+
+COPY --from=requirements /root/.local /usr/local
+COPY authservice/auth.yaml .
+COPY authservice /app/
+
+CMD ["gunicorn", "auth_rest_service:app", "--config", "/app/gunicorn.config.py"]
+
+FROM prod as develop
+
+RUN pip install --user --no-warn-script-location --no-cache-dir \
+                -r /app/requirements-dev.txt
+
+FROM prod
 
 LABEL maintainer="wzhu26@illinois.edu"
 
-WORKDIR /app
-COPY authservice /app/
-COPY lib /lib/
-COPY authservice/auth.yaml .
-
-RUN apk --update add python py-pip openssl ca-certificates py-openssl && \
-  apk --update add --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base && \
-  pip install --upgrade pip && \
-  pip install -r /app/requirements.txt --no-cache-dir && \
-  apk del build-dependencies
-
-CMD ["gunicorn", "auth_rest_service:app", "--config", "/app/gunicorn.config.py"]
+USER nobody

--- a/authservice/requirements-dev.txt
+++ b/authservice/requirements-dev.txt
@@ -1,0 +1,1 @@
+ipython

--- a/authservice/requirements.txt
+++ b/authservice/requirements.txt
@@ -9,6 +9,3 @@ python-dotenv==0.10.3
 gevent==1.4.0
 
 ../lib/auth-middleware
-
-#dev
-ipython

--- a/eventservice/Dockerfile
+++ b/eventservice/Dockerfile
@@ -1,23 +1,34 @@
-FROM python:3-alpine3.11
+FROM python:3-alpine3.11 as base
 
-LABEL maintainer="bing@illinois.edu"
+RUN apk --update add openssl ca-certificates
+
+WORKDIR /app
+COPY lib /lib/
+
+FROM base as requirements
+
+# C libs needed to build cryptography a dependency for requests
+RUN apk --update add libffi-dev openssl-dev build-base
+
+COPY eventservice/requirements.txt /app/eventservice/
+RUN pip install --user --no-warn-script-location --no-cache-dir \
+                -r /app/eventservice/requirements.txt
+RUN chmod -R oug+r /root/.local
+RUN find /root/.local -type d -exec chmod oug+x {} +
+
+FROM base
 
 RUN mkdir -p /app/eventservice/events-images/
 
-WORKDIR /app
+COPY --from=requirements /root/.local /usr/local
 COPY eventservice/events.yaml /app/
 COPY eventservice /app/eventservice/
-COPY lib /lib/
-
-
-RUN apk --update add python3 py3-pip openssl ca-certificates py3-openssl && \
-  apk --update add --virtual build-dependencies libffi-dev openssl-dev python3-dev py3-pip build-base && \
-  pip install --upgrade pip && \
-  pip install -r /app/eventservice/requirements.txt --no-cache-dir && \
-  apk del build-dependencies
-
 
 VOLUME /var/cache/app
 WORKDIR /app/eventservice/api
+
+LABEL maintainer="bing@illinois.edu"
+
+USER nobody
 
 CMD ["gunicorn", "events_rest_service:app", "--config", "/app/eventservice/api/gunicorn.config.py"]

--- a/loggingservice/Dockerfile
+++ b/loggingservice/Dockerfile
@@ -1,22 +1,32 @@
-FROM python:3-alpine3.11
+FROM python:3-alpine3.11 as base
+
+RUN apk --update add openssl ca-certificates
+
+WORKDIR /usr/src/app/lib
+COPY lib .
+
+FROM base as requirements
+
+# C libs needed to build cryptography a dependency for requests
+RUN apk --update add libffi-dev openssl-dev build-base
+
+COPY loggingservice/requirements.txt /
+RUN pip install --user --no-warn-script-location --no-cache-dir \
+                -r /requirements.txt
+RUN chmod -R oug+r /root/.local
+RUN find /root/.local -type d -exec chmod oug+x {} +
+
+FROM base
 
 LABEL maintainer="ywkim@illinois.edu"
 
 EXPOSE 5000
 
-WORKDIR /usr/src/app/lib
-
-COPY lib .
+COPY --from=requirements /root/.local /usr/local
 
 WORKDIR /usr/src/app/loggingservice
 
 COPY loggingservice .
-
-RUN apk --update add python py-pip openssl ca-certificates py-openssl && \
-  apk --update add --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base && \
-  pip install --upgrade pip && \
-  pip install -r requirements.txt --no-cache-dir && \
-  apk del build-dependencies
 
 WORKDIR /usr/src/app/loggingservice/api
 
@@ -24,5 +34,7 @@ COPY loggingservice/logging.yaml .
 
 #ENV LOGGING_MONGO_URL=""
 ENV LOGGING_URL_PREFIX=""
+
+USER nobody
 
 CMD ["gunicorn", "logging_rest_service:app", "--config", "/usr/src/app/loggingservice/api/gunicorn.config.py"]

--- a/profileservice/Dockerfile
+++ b/profileservice/Dockerfile
@@ -1,22 +1,32 @@
-FROM python:3-alpine3.11
+FROM python:3-alpine3.11 as base
+
+RUN apk --update add openssl ca-certificates
+
+WORKDIR /usr/src/app/lib
+COPY lib .
+
+FROM base as requirements
+
+# C libs needed to build cryptography a dependency for requests
+RUN apk --update add libffi-dev openssl-dev build-base
+
+COPY profileservice/requirements.txt /
+RUN pip install --user --no-warn-script-location --no-cache-dir \
+                -r /requirements.txt
+RUN chmod -R oug+r /root/.local
+RUN find /root/.local -type d -exec chmod oug+x {} +
+
+FROM base
 
 LABEL maintainer="ywkim@illinois.edu"
 
 EXPOSE 5000
 
-WORKDIR /usr/src/app/lib
-
-COPY lib .
+COPY --from=requirements /root/.local /usr/local
 
 WORKDIR /usr/src/app/profileservice
 
 COPY profileservice .
-
-RUN apk --update add python py-pip openssl ca-certificates py-openssl && \
-  apk --update add --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base && \
-  pip install --upgrade pip && \
-  pip install -r requirements.txt --no-cache-dir && \
-  apk del build-dependencies
 
 WORKDIR /usr/src/app/profileservice/api
 
@@ -29,5 +39,7 @@ ENV PROFILE_REST_STORAGE="/usr/src/app/rest" \
     FLASK_APP="profile_rest_service" \
     FLASK_ENV="development" \
     PROFILE_URL_PREFIX=""
+
+USER nobody
 
 CMD ["gunicorn", "profile_rest_service:app", "--config", "/usr/src/app/profileservice/api/gunicorn.config.py"]


### PR DESCRIPTION
Optimizations

* Cut appconfigservice to 98.9MB from 216MB
* Cut auth-middleware-test-svc to 71.6MB from 935MB
* Cut authservice to 91.8MB from 228MB
* Cut eventservice to 141MB from 212MB
* Cut loggingservice to 94MB from 211MB
* Cut profileservice to 97.4MB from 215MB
* Reorginized Dockerfile lines to maximize shared layers between containers

Security changes

* All containers now run as a non-root user
   * api-doc runs as nginx user instead of root
    * the rest run as user nobody
* Eliminates all unnecessary development tools used to build
    Python packages