### PR TITLE
Bugfix/560 fix errors in python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Replace the record on put endpoint. [#550](https://github.com/rokwire/rokwire-building-blocks-api/issues/550)
+- Runtime error in building blocks by updating gunicorn and gevent versions. [#560](https://github.com/rokwire/rokwire-building-blocks-api/issues/560)
 
 ### Changed
 - Disabled logger to provide detailed PII information in profile BB. [#556](https://github.com/rokwire/rokwire-building-blocks-api/issues/556)

--- a/appconfigservice/api/controllers/app.py
+++ b/appconfigservice/api/controllers/app.py
@@ -149,6 +149,7 @@ def configs_put(id):
         add_version_numbers(req_data)
         status = db[cfg.APP_CONFIGS_COLLECTION].update_one({'_id': ObjectId(id)}, {"$set": req_data})
         msg = "[PUT]: api config id %s, nUpdate = %d " % (str(id), status.modified_count)
+        __logger.info(msg)
 
     except DuplicateKeyError as err:
         __logger.error(err)

--- a/appconfigservice/requirements.txt
+++ b/appconfigservice/requirements.txt
@@ -4,9 +4,9 @@ pytest==5.0.1
 requests==2.22.0
 pyjwt==1.7.1
 cryptography==2.7
-gunicorn==19.9.0
+gunicorn==20.0.4
 python-dotenv==0.10.3
-gevent==1.4.0
+gevent==20.9.0
 diskcache==4.0.0
 connexion[swagger-ui]==2.4.0
 

--- a/auth-middleware-test-svc/requirements.txt
+++ b/auth-middleware-test-svc/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.1
-gunicorn==19.9.0
+gunicorn==20.0.4
 connexion[swagger-ui]==2.4.0
 python-dotenv==0.10.3
 

--- a/authservice/requirements.txt
+++ b/authservice/requirements.txt
@@ -3,10 +3,10 @@ schema==0.7.0
 connexion[swagger-ui]==2.4.0
 requests==2.22.0
 pyjwt==1.7.1
-gunicorn==19.9.0
+gunicorn==20.0.4
 python-dateutil==2.8.0
 python-dotenv==0.10.3
-gevent==1.4.0
+gevent==20.9.0
 
 ../lib/auth-middleware
 

--- a/eventservice/requirements.txt
+++ b/eventservice/requirements.txt
@@ -1,9 +1,9 @@
 Flask==1.1.1
 pymongo[tls,srv]==3.7.2
-gunicorn==19.9.0
+gunicorn==20.0.4
 boto3==1.9.188
 python-dotenv==0.10.3
-gevent==1.4.0
+gevent==20.9.0
 diskcache==4.0.0
 connexion[swagger-ui]==2.4.0
 

--- a/loggingservice/requirements.txt
+++ b/loggingservice/requirements.txt
@@ -1,8 +1,8 @@
 Flask==1.1.1
 pymongo[tls,srv]==3.7.2
-gunicorn==19.9.0
+gunicorn==20.0.4
 python-dotenv==0.10.3
-gevent==1.4.0
+gevent==20.9.0
 connexion[swagger-ui]==2.4.0
 
 ../lib/auth-middleware

--- a/profileservice/requirements.txt
+++ b/profileservice/requirements.txt
@@ -6,8 +6,8 @@ requests==2.22.0
 pyjwt==1.7.1
 cryptography==2.7
 python-dotenv==0.10.3
-gunicorn==19.9.0
-gevent==1.4.0
+gunicorn==20.0.4
+gevent==20.9.0
 connexion[swagger-ui]==2.4.0
 
 ../lib/auth-middleware


### PR DESCRIPTION
Closes #560 
You can see the error mentioned in the linked issue by creating docker image with the --pull option. For example, `docker build --pull -f eventservice/Dockerfile -t ${PROJECT_NAME}/events-building-block:${VERSION} .` and running the building block as docker container.

This will get the latest version of the base docker image, which is now using Python 3.8. The old gevent version 1.4.0 does not support Python 3.8.