### PR TITLE
Bugfix/562 Runtime error when Auth Library validates manually generated ID tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Replace the record on put endpoint. [#550](https://github.com/rokwire/rokwire-building-blocks-api/issues/550)
 - Runtime error in building blocks by updating gunicorn and gevent versions. [#560](https://github.com/rokwire/rokwire-building-blocks-api/issues/560)
-
+- Runtime error when Auth Library validates manually generated ID tokens. [#562](https://github.com/rokwire/rokwire-building-blocks-api/issues/562)
 ### Changed
 - Disabled logger to provide detailed PII information in profile BB. [#556](https://github.com/rokwire/rokwire-building-blocks-api/issues/556)
 

--- a/lib/auth-middleware/auth_middleware/__init__.py
+++ b/lib/auth-middleware/auth_middleware/__init__.py
@@ -210,7 +210,8 @@ def verify_userauth(id_token, group_name=None, internal_token_only=False):
             #            file1.close()
             lines = base64.b64decode(os.getenv('ROKWIRE_PUB_KEY'))
             keyset = json.loads(lines)
-            target_client_id = os.getenv('ROKWIRE_API_CLIENT_ID')
+
+            target_client_ids = re.split(',', (os.getenv('ROKWIRE_API_CLIENT_ID')).replace(" ", ""))
 
 
         if issuer == 'https://' + SHIB_HOST:

--- a/lib/auth-middleware/auth_middleware/__init__.py
+++ b/lib/auth-middleware/auth_middleware/__init__.py
@@ -196,7 +196,7 @@ def verify_userauth(id_token, group_name=None, internal_token_only=False):
             raise OAuthProblem('Invalid token')
         valid_issuer = False
         keyset = None
-        target_client_id = None
+        target_client_ids = None
 
         if issuer == ROKWIRE_ISSUER:
             valid_issuer = True


### PR DESCRIPTION
Sandeep;
Could you test it with the event thing that you had an error. I tested it in my local using auth-test but I did not know how to replicate the error in event but this should work.