### PR TITLE
1054 bug select contribution type buttons display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Detect secrets GitHub action build error and updated baseline. [#1077](https://github.com/rokwire/rokwire-building-blocks-api/issues/1077)
+- Overlapping divs in catalog contribute create page. [#1054](https://github.com/rokwire/rokwire-building-blocks-api/issues/1054)
 
 ## [1.17.0] - 2022-12-06
 ### Added

--- a/contributions/catalog/webapps/templates/contribute/contribute.html
+++ b/contributions/catalog/webapps/templates/contribute/contribute.html
@@ -165,312 +165,312 @@
             <!-------------- contributor block parent -------------------------->
             <div class="container">
                 <div id="contributor-parent">
-                <!-------------------- organization block clean -------------------->
-                <div id="organization-clean" style="display: none">
-                    <hr class="dotted">
-                    <h3 id="capability">Add an Organization to this Contribution</h3>
-                    <div class="form-group">
-                        <div>
-                            <input id="contributor_type" name="contributor_type" type="hidden" value="organization">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Organization Name</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="org_name" name="org_name" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Organization Address</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="org_address" name="org_address" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Organization Email</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="org_email" name="org_email" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Organization Phone</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="org_phone" name="org_phone" placeholder="" type="text">
-                        </div>
-                    </div>
-                </div>
-
-                <!-------------------- person block clean -------------------->
-                <div id="person-clean" style="display: none">
-                    <hr class="dotted">
-                    <h3 id="capability">Add a Person to this Contribution</h3>
-                    <div class="form-group">
-                        <div>
-                            <input id="contributor_type" name="contributor_type" type="hidden" value="person">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Contributor's first name</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="contributor_fname" name="person_firstName" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Contributor's middle name</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="contributor_mname" name="person_middleName" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Contributor's last name</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="contributor_lname" name="person_lastName" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Contributor Email</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" name="person_email" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Contributor Phone</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" name="person_phone" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Affiliation Name</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" name="affiliation_name" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Affiliation Address</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" name="affiliation_address" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Affiliation Email</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" name="affiliation_email" placeholder="" type="text">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">Affiliation Phone</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" name="affiliation_phone" placeholder="" type="text">
-                        </div>
-                    </div>
-                </div>
-
-                {% if post.contributors %}
-                    {% for contributor in post.contributors %}
-                        {% if contributor["contributorType"] == 'organization' %}
-                            <!-------------------- organization block existing records -------------------->
-                            <div id="organization-existing-records" style="display: block">
-                                <hr class="dotted">
-                                <h3 id="capability">Add an Organization to this Contribution</h3>
-                                <div class="form-group">
-                                    <div>
-                                        <input id="contributor_type_{{loop.index0}}"
-                                               name="contributor_type_{{loop.index0}}"
-                                               type="hidden" value="organization">
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Organization Name</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" id="org_name_{{loop.index0}}"
-                                                   name="org_name_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor|filter_nested_dict(["name"]) }}">
-                                        {% else %}
-                                            <input class="form-control" id="org_name_{{loop.index0}}"
-                                                   name="org_name_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Organization Address</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" id="org_address_{{loop.index0}}"
-                                                   name="org_address_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor|filter_nested_dict(["address"]) }}">
-                                        {% else %}
-                                            <input class="form-control" id="org_address_{{loop.index0}}"
-                                                   name="org_address_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Organization Email</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" id="org_email_{{loop.index0}}"
-                                                   name="org_email_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor|filter_nested_dict(["email"]) }}">
-                                        {% else %}
-                                            <input class="form-control" id="org_email_{{loop.index0}}"
-                                                   name="org_email_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Organization Phone</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" id="org_phone_{{loop.index0}}"
-                                                   name="org_phone_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor|filter_nested_dict(["phone"]) }}">
-                                        {% else %}
-                                            <input class="form-control" id="org_phone_{{loop.index0}}"
-                                                   name="org_phone_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
+                    <!-------------------- organization block clean -------------------->
+                    <div id="organization-clean" style="display: none">
+                        <hr class="dotted">
+                        <h3 id="capability">Add an Organization to this Contribution</h3>
+                        <div class="form-group">
+                            <div>
+                                <input id="contributor_type" name="contributor_type" type="hidden" value="organization">
                             </div>
-                        {% endif %}
-                        {% if contributor["contributorType"] == 'person' %}
-                            <!-------------------- person block existing records -------------------->
-                            <div id="person-existing-records" style="display: block">
-                                <hr class="dotted">
-                                <h3 id="capability">Add a Person to this Contribution</h3>
-                                <div class="form-group">
-                                    <div>
-                                        <input id="contributor_type_{{loop.index0}}"
-                                               name="contributor_type_{{loop.index0}}" type="hidden" value="person">
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Contributor's first name</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" id="contributor_fname_{{loop.index0}}"
-                                                   name="person_firstName_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor | filter_nested_dict(["firstName"]) }}">
-                                        {% else %}
-                                            <input class="form-control" id="contributor_fname_{{loop.index0}}"
-                                                   name="person_firstName_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Contributor's middle name</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" id="contributor_mname_{{loop.index0}}"
-                                                   name="person_middleName_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor | filter_nested_dict(["middleName"]) }}">
-                                        {% else %}
-                                            <input class="form-control" id="contributor_mname_{{loop.index0}}"
-                                                   name="person_middleName_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Contributor's last name</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" id="contributor_lname_{{loop.index0}}"
-                                                   name="person_lastName_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor | filter_nested_dict(["lastName"]) }}">
-                                        {% else %}
-                                            <input class="form-control" id="contributor_lname_{{loop.index0}}"
-                                                   name="person_lastName_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Contributor Email</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" name="person_email_{{loop.index0}}"
-                                                   id="person_email_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor| filter_nested_dict(["email"]) }}">
-                                        {% else %}
-                                            <input class="form-control" name="person_email_{{loop.index0}}"
-                                                   id="person_email_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Contributor Phone</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" name="person_phone_{{loop.index0}}"
-                                                   id="person_phone_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor | filter_nested_dict(["phone"]) }}">
-                                        {% else %}
-                                            <input class="form-control" name="person_phone_{{loop.index0}}"
-                                                   id="person_phone_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Affiliation Name</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" name="affiliation_name_{{loop.index0}}"
-                                                   id="affiliation_name_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor | filter_nested_dict(["affiliation", "name"]) }}">
-                                        {% else %}
-                                            <input class="form-control" name="affiliation_name_{{loop.index0}}"
-                                                   id="affiliation_name_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Affiliation Address</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" name="affiliation_address_{{loop.index0}}"
-                                                   id="affilication_address_{{loop.index0}}"
-                                                   placeholder="" type="text"
-                                                   value="{{ contributor | filter_nested_dict(["affiliation", "address"]) }}">
-                                        {% else %}
-                                            <input class="form-control" name="affiliation_address_{{loop.index0}}"
-                                                   id="affiliation_address_{{loop.index0}}"
-                                                   placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Affiliation Email</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" name="affiliation_email_{{loop.index0}}"
-                                                   id="affiliation_email_{{loop.index0}}" placeholder=""
-                                                   type="text" value="{{ contributor | filter_nested_dict(["affiliation", "email"]) }}">
-                                        {% else %}
-                                            <input class="form-control" name="affiliation_email_{{loop.index0}}"
-                                                   id="affiliation_email_{{loop.index0}}" placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-sm-2">Affiliation Phone</label>
-                                    <div class="col-sm-10">
-                                        {% if is_editable %}
-                                            <input class="form-control" name="affiliation_phone_{{loop.index0}}"
-                                                   id="affiliation_phone_{{loop.index0}}"
-                                                   placeholder="" type="text"
-                                                   value="{{ contributor | filter_nested_dict(["affiliation", "phone"]) }}">
-                                        {% else %}
-                                            <input class="form-control" name="affiliation_phone_{{loop.index0}}"
-                                                   id="affiliation_phone_{{loop.index0}}"
-                                                   placeholder="" type="text">
-                                        {% endif %}
-                                    </div>
-                                </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Organization Name</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="org_name" name="org_name" placeholder="" type="text">
                             </div>
-                        {% endif %}
-                        <script>contributor_count++;</script>
-                    {% endfor %}f
-                {% endif %}
-            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Organization Address</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="org_address" name="org_address" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Organization Email</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="org_email" name="org_email" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Organization Phone</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="org_phone" name="org_phone" placeholder="" type="text">
+                            </div>
+                        </div>
+                    </div> <!--- end of organization block clean -->
+
+                    <!-------------------- person block clean -------------------->
+                    <div id="person-clean" style="display: none">
+                        <hr class="dotted">
+                        <h3 id="capability">Add a Person to this Contribution</h3>
+                        <div class="form-group">
+                            <div>
+                                <input id="contributor_type" name="contributor_type" type="hidden" value="person">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Contributor's first name</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="contributor_fname" name="person_firstName" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Contributor's middle name</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="contributor_mname" name="person_middleName" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Contributor's last name</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" id="contributor_lname" name="person_lastName" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Contributor Email</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" name="person_email" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Contributor Phone</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" name="person_phone" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Affiliation Name</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" name="affiliation_name" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Affiliation Address</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" name="affiliation_address" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Affiliation Email</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" name="affiliation_email" placeholder="" type="text">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">Affiliation Phone</label>
+                            <div class="col-sm-10">
+                                <input class="form-control" name="affiliation_phone" placeholder="" type="text">
+                            </div>
+                        </div>
+                    </div> <!-- end of person block clean -->
+
+                    {% if post.contributors %}
+                        {% for contributor in post.contributors %}
+                            {% if contributor["contributorType"] == 'organization' %}
+                                <!-------------------- organization block existing records -------------------->
+                                <div id="organization-existing-records" style="display: block">
+                                    <hr class="dotted">
+                                    <h3 id="capability">Add an Organization to this Contribution</h3>
+                                    <div class="form-group">
+                                        <div>
+                                            <input id="contributor_type_{{loop.index0}}"
+                                                   name="contributor_type_{{loop.index0}}"
+                                                   type="hidden" value="organization">
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Organization Name</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" id="org_name_{{loop.index0}}"
+                                                       name="org_name_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor|filter_nested_dict(["name"]) }}">
+                                            {% else %}
+                                                <input class="form-control" id="org_name_{{loop.index0}}"
+                                                       name="org_name_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Organization Address</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" id="org_address_{{loop.index0}}"
+                                                       name="org_address_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor|filter_nested_dict(["address"]) }}">
+                                            {% else %}
+                                                <input class="form-control" id="org_address_{{loop.index0}}"
+                                                       name="org_address_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Organization Email</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" id="org_email_{{loop.index0}}"
+                                                       name="org_email_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor|filter_nested_dict(["email"]) }}">
+                                            {% else %}
+                                                <input class="form-control" id="org_email_{{loop.index0}}"
+                                                       name="org_email_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Organization Phone</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" id="org_phone_{{loop.index0}}"
+                                                       name="org_phone_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor|filter_nested_dict(["phone"]) }}">
+                                            {% else %}
+                                                <input class="form-control" id="org_phone_{{loop.index0}}"
+                                                       name="org_phone_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endif %}
+                            {% if contributor["contributorType"] == 'person' %}
+                                <!-------------------- person block existing records -------------------->
+                                <div id="person-existing-records" style="display: block">
+                                    <hr class="dotted">
+                                    <h3 id="capability">Add a Person to this Contribution</h3>
+                                    <div class="form-group">
+                                        <div>
+                                            <input id="contributor_type_{{loop.index0}}"
+                                                   name="contributor_type_{{loop.index0}}" type="hidden" value="person">
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Contributor's first name</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" id="contributor_fname_{{loop.index0}}"
+                                                       name="person_firstName_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor | filter_nested_dict(["firstName"]) }}">
+                                            {% else %}
+                                                <input class="form-control" id="contributor_fname_{{loop.index0}}"
+                                                       name="person_firstName_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Contributor's middle name</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" id="contributor_mname_{{loop.index0}}"
+                                                       name="person_middleName_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor | filter_nested_dict(["middleName"]) }}">
+                                            {% else %}
+                                                <input class="form-control" id="contributor_mname_{{loop.index0}}"
+                                                       name="person_middleName_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Contributor's last name</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" id="contributor_lname_{{loop.index0}}"
+                                                       name="person_lastName_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor | filter_nested_dict(["lastName"]) }}">
+                                            {% else %}
+                                                <input class="form-control" id="contributor_lname_{{loop.index0}}"
+                                                       name="person_lastName_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Contributor Email</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" name="person_email_{{loop.index0}}"
+                                                       id="person_email_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor| filter_nested_dict(["email"]) }}">
+                                            {% else %}
+                                                <input class="form-control" name="person_email_{{loop.index0}}"
+                                                       id="person_email_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Contributor Phone</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" name="person_phone_{{loop.index0}}"
+                                                       id="person_phone_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor | filter_nested_dict(["phone"]) }}">
+                                            {% else %}
+                                                <input class="form-control" name="person_phone_{{loop.index0}}"
+                                                       id="person_phone_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Affiliation Name</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" name="affiliation_name_{{loop.index0}}"
+                                                       id="affiliation_name_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor | filter_nested_dict(["affiliation", "name"]) }}">
+                                            {% else %}
+                                                <input class="form-control" name="affiliation_name_{{loop.index0}}"
+                                                       id="affiliation_name_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Affiliation Address</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" name="affiliation_address_{{loop.index0}}"
+                                                       id="affilication_address_{{loop.index0}}"
+                                                       placeholder="" type="text"
+                                                       value="{{ contributor | filter_nested_dict(["affiliation", "address"]) }}">
+                                            {% else %}
+                                                <input class="form-control" name="affiliation_address_{{loop.index0}}"
+                                                       id="affiliation_address_{{loop.index0}}"
+                                                       placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Affiliation Email</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" name="affiliation_email_{{loop.index0}}"
+                                                       id="affiliation_email_{{loop.index0}}" placeholder=""
+                                                       type="text" value="{{ contributor | filter_nested_dict(["affiliation", "email"]) }}">
+                                            {% else %}
+                                                <input class="form-control" name="affiliation_email_{{loop.index0}}"
+                                                       id="affiliation_email_{{loop.index0}}" placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="control-label col-sm-2">Affiliation Phone</label>
+                                        <div class="col-sm-10">
+                                            {% if is_editable %}
+                                                <input class="form-control" name="affiliation_phone_{{loop.index0}}"
+                                                       id="affiliation_phone_{{loop.index0}}"
+                                                       placeholder="" type="text"
+                                                       value="{{ contributor | filter_nested_dict(["affiliation", "phone"]) }}">
+                                            {% else %}
+                                                <input class="form-control" name="affiliation_phone_{{loop.index0}}"
+                                                       id="affiliation_phone_{{loop.index0}}"
+                                                       placeholder="" type="text">
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endif %}
+                            <script>contributor_count++;</script>
+                        {% endfor %}f
+                    {% endif %}
+                </div> {# end of contributor block parent div #}
             </div> {# end of contributor block parent container div #}
 
             <div id="cd-multi-steps-text-top">

--- a/contributions/catalog/webapps/templates/contribute/contribute.html
+++ b/contributions/catalog/webapps/templates/contribute/contribute.html
@@ -473,12 +473,11 @@
                 </div> {# end of contributor block parent div #}
             </div> {# end of contributor block parent container div #}
 
-            <div id="cd-multi-steps-text-top">
+            <div class="container" id="cd-multi-steps-text-top">
                 <nav>
                     <ol class="cd-multi-steps text-top">
                         <li class="visited"><em><a href="#contribute">Contribution Details</a></em></li>
-                        <li class="current"><em><a href="#capability-parent">Capability / Talent Details </a></em>
-                        </li>
+                        <li class="current"><em><a href="#capability-parent">Capability / Talent Details </a></em></li>
                         <li><em><a href="#contact">Contact Details</a></em></li>
                         <li><em><a href="#submit">Submit</a></em></li>
                     </ol>
@@ -1636,12 +1635,11 @@
             </div>
 
             <!--------------------------------------------contact/privacy check ------------------------------------------>
-            <div id="cd-multi-steps-text-bottom">
+            <div id="cd-multi-steps-text-bottom" class="container">
                 <nav>
                     <ol class="cd-multi-steps text-top">
                         <li class="visited"><a href="#contribute">Contribution Details</a></li>
-                        <li class="visited"><em><a href="#capability-parent">Capability / Talent Details </a></em>
-                        </li>
+                        <li class="visited"><em><a href="#capability-parent">Capability / Talent Details </a></em></li>
                         <li class="current"><em><a href="#contact">Contact Details</a></em></li>
                         <li><em><a href="#submit">Submit</a></em></li>
                     </ol>

--- a/contributions/catalog/webapps/templates/contribute/contribute.html
+++ b/contributions/catalog/webapps/templates/contribute/contribute.html
@@ -1635,7 +1635,7 @@
             </div>
 
             <!--------------------------------------------contact/privacy check ------------------------------------------>
-            <div id="cd-multi-steps-text-bottom" class="container">
+            <div id="cd-multi-steps-text-bottom" class="container" style="margin-top:3cm">
                 <nav>
                     <ol class="cd-multi-steps text-top">
                         <li class="visited"><a href="#contribute">Contribution Details</a></li>
@@ -2291,9 +2291,9 @@
         // adjust button position
         event.preventDefault();
         $('#select-contribution-div').position({
-            my: "top",
-            at: "bottom",
-            of: $("#select-contribution-div-placeholder"),
+            my: "bottom",
+            at: "top",
+            of: $("#cd-multi-steps-text-bottom"),
             collision: "none none"
         });
     }


### PR DESCRIPTION
## Description
Overlapping of divs on dynamic change of contribute create page fields is fixed.
The breadcrumb divs are changed to container classes. The MoveSelector function now places the "select contribution type" buttons above the breadcrumbs at the bottom (div id #cd-multi-steps-text-bottom).

Tried multiple field changes like adding and removing environment variables, open source code radio button on and off , adding and deleting capability/talent.

**Fixes #1054**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [x] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)

